### PR TITLE
Name library "skype" instead of "libskype"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,8 +13,8 @@ set(LIBSOURCES ${LIBSOURCES}
 	)
 
 
-add_library(libskype SHARED ${LIBSOURCES})
+add_library(skype SHARED ${LIBSOURCES})
 
 add_executable(skypecli skypecli.cpp)
-target_link_libraries(skypecli libskype)
+target_link_libraries(skypecli skype)
 


### PR DESCRIPTION
Without this change, it ends up being named "liblibskype.so" on *nix systems.

Also, It isn't linking with stdc++ on clang for some reason.
